### PR TITLE
Remove bottle :unneeded from the tap

### DIFF
--- a/Formula/zoe.rb
+++ b/Formula/zoe.rb
@@ -1,7 +1,6 @@
 class Zoe < Formula
   desc "The kafka CLI for humans"
   homepage "https://adevinta.github.io/zoe"
-  bottle :unneeded
   version "0.27.3"
   
   url "https://github.com/adevinta/zoe/releases/download/v0.27.3/zoe-0.27.3.zip"

--- a/dev/scripts/helper.main.kts
+++ b/dev/scripts/helper.main.kts
@@ -38,7 +38,6 @@ fun generateFormula(version: String, url: String, hash: String) = """
     |class Zoe < Formula
     |  desc "The kafka CLI for humans"
     |  homepage "https://adevinta.github.io/zoe"
-    |  bottle :unneeded
     |  version "$version"
     |  
     |  url "$url"


### PR DESCRIPTION
Homebrew does not support `bottle :unneeded` anymore.
We have this warning while running `brew`.

```shell
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the adevinta/zoe tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/adevinta/homebrew-zoe/Formula/zoe.rb:4
```